### PR TITLE
⬆️ Bump paper to 1.19.2

### DIFF
--- a/mcorouhlin-paper/build.gradle.kts
+++ b/mcorouhlin-paper/build.gradle.kts
@@ -15,7 +15,7 @@ repositories {
 
 dependencies {
     api(project(":mcorouhlin-api"))
-    paperDevBundle("1.19.1-R0.1-SNAPSHOT")
+    paperDevBundle("1.19.2-R0.1-SNAPSHOT")
 
     implementation("net.kyori:adventure-extra-kotlin:4.11.0") {
         exclude("net.kyori")


### PR DESCRIPTION
Bump `paper-dev-bundle` and `paper-api` to `1.19.2`.